### PR TITLE
Made RouterTarget `Copy`, so it can be passed around.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub use crate::router::{Request, Route, RouterAgent};
 /// Convinience macro for route creation
 macro_rules! routes {
     ($($x:tt => $y:expr,)*) => (
-        #[derive(Debug, PartialEq)]
+        #[derive(Debug, PartialEq, Clone, Copy)]
         /// Possible child components
         pub enum RouterTarget {
             $($x,)*


### PR DESCRIPTION
Fixes #216.

Note that I can't actually test this revision, because master doesn't compile for me. However, I cherry-picked this onto the revision with the `v0.4.0` tag and it worked fine.